### PR TITLE
Remove address widget media

### DIFF
--- a/address/widgets.py
+++ b/address/widgets.py
@@ -26,30 +26,6 @@ class AddressWidget(forms.TextInput):
                   ('formatted', 'formatted_address'),
                   ('latitude', 'lat'), ('longitude', 'lng')]
 
-    class Media:
-        """Media defined as a dynamic property instead of an inner class."""
-        js = [
-            'https://maps.googleapis.com/maps/api/js?libraries=places&key=%s' % settings.GOOGLE_API_KEY,
-            'js/jquery.geocomplete.min.js',
-            'address/js/address.js',
-        ]
-
-        if JQUERY_URL:
-            js.insert(0, JQUERY_URL)
-        elif JQUERY_URL is not False:
-            vendor = '' if django.VERSION < (1, 9, 0) else 'vendor/jquery/'
-            extra = '' if settings.DEBUG else '.min'
-
-            jquery_paths = [
-                '{}jquery{}.js'.format(vendor, extra),
-                'jquery.init.js',
-            ]
-
-            if USE_DJANGO_JQUERY:
-                jquery_paths = ['admin/js/{}'.format(path) for path in jquery_paths]
-
-            js.extend(jquery_paths)
-
     def __init__(self, *args, **kwargs):
         attrs = kwargs.get('attrs', {})
         classes = attrs.get('class', '')

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 from setuptools import find_packages, setup
 
-version = '0.2.2+nimbis.1'
+version = '0.2.2+nimbis.2'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
This change was originally applied back in 2018, but was lost in the upgrade to django-address 0.2.2. While we tried to get rid of another fork to maintain, this regression breaks the address field on the sign up form. Additionally, we have a drafted PR for removing django-address so its removal is imminent, and we will likely only be maintaining this fork for a short period of time.